### PR TITLE
Update hello world example for LLVM 6.0.0 support

### DIFF
--- a/helloWorld.ll
+++ b/helloWorld.ll
@@ -6,15 +6,15 @@
 declare i32 @puts(i8* nocapture) nounwind
 
 ; Definition of main function
-define i32 @main() {   ; i32()*
-      ; Convert [13 x i8]* to i8  *...
-        %cast210 = getelementptr [13 x i8]* @.str, i64 0, i64 0
+define i32 @main() { ; i32()*
+    ; Convert [13 x i8]* to i8  *...
+    %cast210 = getelementptr [13 x i8],[13 x i8]* @.str, i64 0, i64 0
 
-          ; Call puts function to write out the string to stdout.
-            call i32 @puts(i8* %cast210)
-              ret i32 0
+    ; Call puts function to write out the string to stdout.
+    call i32 @puts(i8* %cast210)
+    ret i32 0
 }
 
 ; Named metadata
-!1 = metadata !{i32 42}
-!foo = !{!1, !1}
+!0 = !{i32 42, null, !"string"}
+!foo = !{!0}

--- a/helloWorld.s
+++ b/helloWorld.s
@@ -1,22 +1,37 @@
-	.section	__TEXT,__text,regular,pure_instructions
-	.globl	_main
-	.align	4, 0x90
-_main:                                  ## @main
-	.cfi_startproc
-## BB#0:
-	pushq	%rax
-Ltmp1:
-	.cfi_def_cfa_offset 16
-	leaq	L_.str(%rip), %rdi
-	callq	_puts
+	.text
+	.def	 main;
+	.scl	2;
+	.type	32;
+	.endef
+	.globl	main                    # -- Begin function main
+	.p2align	4, 0x90
+main:                                   # @main
+.seh_proc main
+# %bb.0:
+	pushq	%rbp
+	.seh_pushreg 5
+	pushq	%rsi
+	.seh_pushreg 6
+	subq	$40, %rsp
+	.seh_stackalloc 40
+	leaq	32(%rsp), %rbp
+	.seh_setframe 5, 32
+	.seh_endprologue
+	leaq	.L.str(%rip), %rsi
+	callq	__main
+	movq	%rsi, %rcx
+	callq	puts
 	xorl	%eax, %eax
-	popq	%rdx
-	ret
-	.cfi_endproc
+	addq	$40, %rsp
+	popq	%rsi
+	popq	%rbp
+	retq
+	.seh_handlerdata
+	.text
+	.seh_endproc
+                                        # -- End function
+	.section	.rdata,"dr"
+.L.str:                                 # @.str
+	.asciz	"hello world\n"
 
-	.section	__TEXT,__cstring,cstring_literals
-L_.str:                                 ## @.str
-	.asciz	 "hello world\n"
 
-
-.subsections_via_symbols


### PR DESCRIPTION
This patch fixes two primary issues with the original hello world example
1) The initialization of the @main%cast210 variable was missing a specification of the element pointer type.
2) There were changes to the named metadata format that broke the compilation after the aforementioned issue had been resolved.

Reference: http://releases.llvm.org/6.0.0/docs/LangRef.html#module-structure